### PR TITLE
Add \u2E17 as a hyphenation mark

### DIFF
--- a/Document/Document.tcc
+++ b/Document/Document.tcc
@@ -168,7 +168,7 @@ namespace OCRCorrection {
 
 
     void Document::findHyphenation() {
-	std::wstring hyphenationMarks = std::wstring( L"-\u00AC" );
+	std::wstring hyphenationMarks = std::wstring( L"-\u00AC\u2E17" );
 	std::wstring mergedWord;
 
 

--- a/Document/Test/TestDocument.h
+++ b/Document/Test/TestDocument.h
@@ -290,6 +290,12 @@ namespace OCRCorrection {
 	doc.pushBackToken( L"\u00AC", false ); // using the "not" sign, unicode U+00AC
 	doc.pushBackToken( L"\n", false );
 	doc.pushBackToken( L"umbruch", true );
+	doc.pushBackToken( L"und", true );
+	doc.pushBackToken( L"zeilen", true );
+	doc.pushBackToken( L"\u2E17", false );  // Double Oblique Hyphen
+	doc.pushBackToken( L"\n", false );
+	doc.pushBackToken( L"umbruch", true );
+
 
 	doc.findHyphenation();
 	CPPUNIT_ASSERT( doc.at( 2 ).hasProperty( Token::HYPHENATION_1ST ) );
@@ -304,7 +310,11 @@ namespace OCRCorrection {
 	CPPUNIT_ASSERT( doc.at( 11 ).hasProperty( Token::HYPHENATION_2ND ) );
 	CPPUNIT_ASSERT( doc.at( 11 ).getHyphenationMerged() == L"zeilenumbruch" );
 
-
+	CPPUNIT_ASSERT( doc.at( 13 ).hasProperty( Token::HYPHENATION_1ST ) );
+	CPPUNIT_ASSERT( doc.at( 13 ).getHyphenationMerged() == L"zeilenumbruch" );
+	CPPUNIT_ASSERT( doc.at( 14 ).hasProperty( Token::HYPHENATION_MARK ) );
+	CPPUNIT_ASSERT( doc.at( 16 ).hasProperty( Token::HYPHENATION_2ND ) );
+	CPPUNIT_ASSERT( doc.at( 16 ).getHyphenationMerged() == L"zeilenumbruch" );
     }
 
 }


### PR DESCRIPTION
\u2E17 is used in historical German texts as a hyphenation mark