### PR TITLE
add missing std:: headers for AutoCorrector.cxx and Profile.hxx

### DIFF
--- a/GtDoc/AutoCorrector.cxx
+++ b/GtDoc/AutoCorrector.cxx
@@ -1,4 +1,6 @@
 #include <regex>
+#include <map>
+#include <system_error>
 #include "AutoCorrector.h"
 #include "Document/Document.h"
 #include "Utils/Utils.h"

--- a/Profiler/Profile.hxx
+++ b/Profiler/Profile.hxx
@@ -5,6 +5,8 @@
 #include "WeightedCandidate.hxx"
 #include <functional>
 #include <unordered_map>
+#include <memory>
+
 
 namespace csl {
 template <class T> class MinDic;


### PR DESCRIPTION
I still cannot get the Profiler to compile though:

```
[ 76%] Building CXX object Profiler/CMakeFiles/profiler.dir/exec_profiler.o
/home/kba/build/github.com/OCR-D/monorepo/Profiler/Profiler/exec_profiler.cxx: In function ‘int main(int, const char**)’:
/home/kba/build/github.com/OCR-D/monorepo/Profiler/Profiler/exec_profiler.cxx:295:64: error: use of deleted function ‘std::basic_ofstream<wchar_t>::basic_ofstream(const std::basic_ofstream<wchar_t>&)’
       auto out = std::wofstream(options.getOption("jsonOutput"));
                                                                ^
In file included from /home/kba/build/github.com/OCR-D/monorepo/Profiler/Profiler/./Profiler.h:4:0,
                 from /home/kba/build/github.com/OCR-D/monorepo/Profiler/Profiler/exec_profiler.cxx:10:
/usr/include/c++/4.9/fstream:602:11: note: ‘std::basic_ofstream<wchar_t>::basic_ofstream(const std::basic_ofstream<wchar_t>&)’ is implicitly deleted because the default definition would be ill-formed:
     class basic_ofstream : public basic_ostream<_CharT,_Traits>
           ^
/usr/include/c++/4.9/fstream:602:11: error: use of deleted function ‘std::basic_ostream<wchar_t>::basic_ostream(const std::basic_ostream<wchar_t>&)’
In file included from /usr/include/c++/4.9/iostream:39:0,
                 from /home/kba/build/github.com/OCR-D/monorepo/Profiler/Profiler/exec_profiler.cxx:1:
/usr/include/c++/4.9/ostream:58:11: note: ‘std::basic_ostream<wchar_t>::basic_ostream(const std::basic_ostream<wchar_t>&)’ is implicitly deleted because the default definition would be ill-formed:
     class basic_ostream : virtual public basic_ios<_CharT, _Traits>
           ^
/usr/include/c++/4.9/ostream:58:11: error: use of deleted function ‘std::basic_ios<wchar_t>::basic_ios(const std::basic_ios<wchar_t>&)’
In file included from /usr/include/c++/4.9/ios:44:0,
                 from /usr/include/c++/4.9/ostream:38,
                 from /usr/include/c++/4.9/iostream:39,
                 from /home/kba/build/github.com/OCR-D/monorepo/Profiler/Profiler/exec_profiler.cxx:1:
/usr/include/c++/4.9/bits/basic_ios.h:66:11: note: ‘std::basic_ios<wchar_t>::basic_ios(const std::basic_ios<wchar_t>&)’ is implicitly deleted because the default definition would be ill-formed:
     class basic_ios : public ios_base
           ^
In file included from /usr/include/c++/4.9/ios:42:0,
                 from /usr/include/c++/4.9/ostream:38,
                 from /usr/include/c++/4.9/iostream:39,
                 from /home/kba/build/github.com/OCR-D/monorepo/Profiler/Profiler/exec_profiler.cxx:1:
/usr/include/c++/4.9/bits/ios_base.h:786:5: error: ‘std::ios_base::ios_base(const std::ios_base&)’ is private
     ios_base(const ios_base&);
     ^
In file included from /usr/include/c++/4.9/ios:44:0,
                 from /usr/include/c++/4.9/ostream:38,
                 from /usr/include/c++/4.9/iostream:39,
                 from /home/kba/build/github.com/OCR-D/monorepo/Profiler/Profiler/exec_profiler.cxx:1:
/usr/include/c++/4.9/bits/basic_ios.h:66:11: error: within this context
     class basic_ios : public ios_base
           ^
In file included from /home/kba/build/github.com/OCR-D/monorepo/Profiler/Profiler/./Profiler.h:4:0,
                 from /home/kba/build/github.com/OCR-D/monorepo/Profiler/Profiler/exec_profiler.cxx:10:
/usr/include/c++/4.9/fstream:602:11: error: use of deleted function ‘std::basic_ios<wchar_t>::basic_ios(const std::basic_ios<wchar_t>&)’
     class basic_ofstream : public basic_ostream<_CharT,_Traits>
           ^
/usr/include/c++/4.9/fstream:602:11: error: use of deleted function ‘std::basic_filebuf<wchar_t>::basic_filebuf(const std::basic_filebuf<wchar_t>&)’
/usr/include/c++/4.9/fstream:72:11: note: ‘std::basic_filebuf<wchar_t>::basic_filebuf(const std::basic_filebuf<wchar_t>&)’ is implicitly deleted because the default definition would be ill-formed:
     class basic_filebuf : public basic_streambuf<_CharT, _Traits>
           ^
In file included from /usr/include/c++/4.9/ios:43:0,
                 from /usr/include/c++/4.9/ostream:38,
                 from /usr/include/c++/4.9/iostream:39,
                 from /home/kba/build/github.com/OCR-D/monorepo/Profiler/Profiler/exec_profiler.cxx:1:
/usr/include/c++/4.9/streambuf:802:7: error: ‘std::basic_streambuf<_CharT, _Traits>::basic_streambuf(const std::basic_streambuf<_CharT, _Traits>&) [with _CharT = wchar_t; _Traits = std::char_traits<wchar_t>]’ is private
       basic_streambuf(const basic_streambuf& __sb)
       ^
In file included from /home/kba/build/github.com/OCR-D/monorepo/Profiler/Profiler/./Profiler.h:4:0,
                 from /home/kba/build/github.com/OCR-D/monorepo/Profiler/Profiler/exec_profiler.cxx:10:
/usr/include/c++/4.9/fstream:72:11: error: within this context
     class basic_filebuf : public basic_streambuf<_CharT, _Traits>
           ^
Profiler/CMakeFiles/profiler.dir/build.make:54: recipe for target 'Profiler/CMakeFiles/profiler.dir/exec_profiler.o' failed
make[3]: *** [Profiler/CMakeFiles/profiler.dir/exec_profiler.o] Error 1
make[3]: Leaving directory '/data/monorepo/Profiler/build'
CMakeFiles/Makefile2:1493: recipe for target 'Profiler/CMakeFiles/profiler.dir/all' failed
make[2]: *** [Profiler/CMakeFiles/profiler.dir/all] Error 2
make[2]: Leaving directory '/data/monorepo/Profiler/build'
Makefile:117: recipe for target 'all' failed
make[1]: *** [all] Error 2
make[1]: Leaving directory '/data/monorepo/Profiler/build'
Makefile:12: recipe for target 'build/bin/profiler' failed
make: *** [build/bin/profiler] Error 2
```

My C++ is a bit rusty. Is my compiler too old (gcc4.9)? Too new? Something in the code? Something in my setup?